### PR TITLE
MELT schema requires array of blocks

### DIFF
--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -96,7 +96,7 @@ module Fluent
         end
         io = StringIO.new
         gzip = Zlib::GzipWriter.new(io)
-        gzip << payload.to_json
+        gzip << [payload].to_json
         gzip.close
         attempt_send(io.string, 0)
       end

--- a/lib/newrelic-fluentd-output/version.rb
+++ b/lib/newrelic-fluentd-output/version.rb
@@ -1,3 +1,3 @@
 module NewrelicFluentdOutput
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/fluent/plugin/newrelic-fluentd-output_spec.rb
+++ b/spec/fluent/plugin/newrelic-fluentd-output_spec.rb
@@ -263,7 +263,8 @@ class Fluent::Plugin::NewrelicOutputTest < Test::Unit::TestCase
   end
 
   def parsed_gzipped_json(body)
-    JSON.parse(gunzip(body))
+    request = JSON.parse(gunzip(body))
+    request[0] # The schema requires an array of log blocks, but this plugin only ever creates a single block
   end
 
   def create_driver(conf)


### PR DESCRIPTION
This was just sending one block, but the schema requires an
array of them.