### PR TITLE
Utilize nsec info in timestamp whenever available

### DIFF
--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -67,6 +67,9 @@ module Fluent
       end
 
       def package_record(record, timestamp)
+        if defined? timestamp.nsec
+          timestamp = timestamp * 1000 + timestamp.nsec / 1_000_000
+        end
         packaged = {
           'timestamp' => timestamp,
           # non-intrinsic attributes get put into 'attributes'

--- a/lib/newrelic-fluentd-output/version.rb
+++ b/lib/newrelic-fluentd-output/version.rb
@@ -1,3 +1,3 @@
 module NewrelicFluentdOutput
-  VERSION = "1.1.5"
+  VERSION = "1.1.8"
 end


### PR DESCRIPTION
closes #19 

The most general way I found to detect if the nsec info is available is using `defined? timestamp.nsec`, since sometimes `timestamp` is an integer, sometimes an object (maybe depending on the upstream plugins). Feel free to suggest if there are better ways to implement it. :)