### PR TITLE
Add Fluentd configuration examples

### DIFF
--- a/examples/Windows-IIS.conf
+++ b/examples/Windows-IIS.conf
@@ -1,0 +1,85 @@
+####
+## New Relic Logs - Basic Windows Event + IIS config v1.5
+## Built in FluentD v1.7.4
+## by AI of NR 2/4/2020
+##
+## Don't forget to add your NR license key to the <match> statement at the bottom of this file.
+##
+
+## Windows Event Log Input
+<source>
+  @type windows_eventlog
+  @id windows_eventlog
+  tag winevt.raw
+  channels application,system,security
+  <storage>
+    @type local
+    persistent true
+    path c:/opt/td-agent/winevt.pos
+  </storage>
+</source>
+
+#
+# Windows IIS log parsing.  This config uses the standard W3C format and the standard location for IIS logs.
+# It expects the log timestamp to be UTC.
+# Change the path below if you store your logs elsewhere.
+#
+<source>
+  @type tail
+  tag iislog.raw
+  path c:/inetpub/logs/logfiles/*/*
+  pos_file c:/opt/td-agent/iislog.pos
+  <parse>
+    @type regexp
+    expression /(?<time>\d{4}-\d{2}-\d{2} [\d:]+) (?<message>.+)/
+    time_format %Y-%m-%d %H:%M:%S
+	utc true
+  </parse>
+</source>
+
+<filter iislog.raw>
+  @type parser
+  key_name message
+  remove_key_name_field false
+  reserve_data true
+  reserve_time true
+  <parse>
+    @type csv
+    delimiter ' '
+    keys hostname,req_method,req_uri,cs-uri-query,s_port,cs-username,c_ip,req_ua,req_referer,http_code,sc-substatus,sc-win32-status,time-taken
+    null_value_pattern -
+    null_empty_string true
+  </parse>
+</filter>
+
+#
+# For a slightly nicer experience, add Service Name (s-sitename) to your log output, comment out the filter above and use this one instead.
+#
+#<filter iislog.raw>
+#  @type parser
+#  key_name message
+#  remove_key_name_field false
+#  reserve_data true
+#  reserve_time true
+#  <parse>
+#    @type csv
+#    delimiter ' '
+#    keys service_name,hostname,req_method,req_uri,cs-uri-query,s_port,cs-username,c_ip,req_ua,req_referer,http_code,sc-substatus,sc-win32-status,time-taken
+#    null_value_pattern -
+#    null_empty_string true
+#  </parse>
+#</filter>
+
+<filter winevt.raw>
+  @type record_transformer
+  <record>
+    message ${record["description"]}
+	  hostname ${record["computer_name"]}
+  </record>
+</filter>
+
+# New Relic output
+<match **>
+  @type newrelic
+  license_key (YourNRLicenseKeyHere)
+</match>

--- a/examples/Windows-IIS.conf
+++ b/examples/Windows-IIS.conf
@@ -81,5 +81,5 @@
 # New Relic output
 <match **>
   @type newrelic
-  license_key (YourNRLicenseKeyHere)
+  api_key <YOUR INSERT KEY>
 </match>

--- a/examples/copy_output.conf
+++ b/examples/copy_output.conf
@@ -1,0 +1,43 @@
+#Tail and parse Apache access logs
+
+<source>
+   @type tail
+   @id input_tail_apache
+   tag apache_access
+   path /var/log/apache2/access.log
+   pos_file /var/log/apache2/access.pos
+   path_key filename
+   <parse>
+   @type apache2
+   </parse>
+ </source>
+ 
+ #Add hostname and tag fields to all events ("records") with a Fluentd tag of apache_access
+ 
+ <filter apache_access>
+  @type record_transformer
+  <record>
+    hostname "#{Socket.gethostname}"
+    tag ${tag}
+  </record>
+</filter>
+
+#Output (https://docs.fluentd.org/output/copy) events to both New Relic and a local file.
+
+<match **>
+  @type copy
+  <store>
+  @type newrelic
+  api_key <YOUR INSERT KEY>
+  </store>
+  <store>
+  @type file
+  path /var/log/apacheout.log
+  <buffer>
+    #Buffer settings are for testing and not recommended for use in a production environment.
+    timekey 10s
+    timekey_use_utc true
+    timekey_wait 15s
+  </buffer>
+  </store>
+</match>

--- a/examples/custom_field.conf
+++ b/examples/custom_field.conf
@@ -1,0 +1,35 @@
+#Tail and parse Docker log files
+
+<source>
+  @type tail
+  path /var/lib/docker/containers/*/*-json.log
+  pos_file /var/log/docker-log.pos
+  read_from_head true
+  tag containers
+  <parse>
+    @type json
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+    keep_time_key true
+    time_key time
+  </parse>
+</source>
+
+#Convert timestamp to Unix epoch (milliseconds) using Ruby. 
+
+<filter containers>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    timestamp ${Integer(DateTime.parse(record["time"]).strftime("%Q"))}
+    #Add hostname and tag fields to all records
+    hostname "#{Socket.gethostname}"
+    tag ${tag}
+  </record>
+</filter>
+
+# Forward events to New Relic
+
+<match containers>
+  @type newrelic
+  api_key <YOUR INSERT KEY>
+  </match>

--- a/examples/file_input.conf
+++ b/examples/file_input.conf
@@ -1,0 +1,29 @@
+#Tail arbitrary text/log file
+
+<source>
+  @type tail
+  <parse>
+    @type none
+  </parse>
+  path /var/log/backend-app*.log
+  pos_file /var/log/backend.application.pos
+  path_key filename # Add watched file path to path_key field for every event/record.
+  tag backend.application
+</source>
+
+ #Add hostname and tag fields to all events ("records") with a Fluentd tag of backend.application
+ 
+ <filter backend.application>
+  @type record_transformer
+  <record>
+    hostname "#{Socket.gethostname}"
+    tag ${tag}
+  </record>
+</filter>
+
+#Write events to New Relic
+
+<match backend.application>
+  @type newrelic
+  api_key <YOUR INSERT KEY>
+</match>

--- a/examples/filter_logs.conf
+++ b/examples/filter_logs.conf
@@ -1,0 +1,52 @@
+#Tail and parse arbitrary text/log file
+
+<source>
+  @type tail
+  <parse> #Parse timestamp, everything else to be stored in message field
+    @type regexp
+    expression /^\[(?<logtime>[^\]]*)\] (?<message>.*)$/
+    time_key logtime
+    time_format %Y-%m-%d %H:%M:%S %z
+  </parse>
+  path /var/log/backend-app*.log
+  pos_file /var/log/backend.application.pos
+  path_key filename # Add watched file path to path_key field for every event/record.
+  tag backend.application
+</source>
+
+#Add hostname and service_name fields to all events ("records") with a Fluentd tag of backend.application
+ 
+<filter backend.application>
+  @type record_transformer
+  <record>
+    hostname "#{Socket.gethostname}"
+    service_name ${tag}
+  </record>
+</filter>
+
+# For all events with a tag of backend.application:
+# Keep ONLY events where service_name field contains a value matching /backend.application/ AND where message field contains a value matching /Cannot connect to/
+# Discard any events where value of hostname field matches /staging/
+
+<filter backend.application>
+  @type grep
+  <regexp>
+    key service_name
+    pattern /backend.application/
+  </regexp>
+   <regexp>
+    key message
+    pattern /Cannot connect to/
+  </regexp>
+  <exclude>
+    key hostname
+    pattern /staging/
+  </exclude>
+</filter>
+
+#Write events with backend.application tag to New Relic
+
+<match backend.application>
+  @type newrelic
+  api_key <YOUR INSERT KEY>
+</match>

--- a/examples/grok_parser.conf
+++ b/examples/grok_parser.conf
@@ -1,0 +1,43 @@
+#Tail arbitrary log file and parse using grok pattern
+#Install the required plugin: fluent-gem install fluent-plugin-grok-parser
+
+<source>
+  @type tail
+  <parse>
+    @type grok
+    <grok>
+      pattern %{SYSLOGTIMESTAMP:timestamp} %{LOGLEVEL:loglevel}: %{GREEDYDATA:message}
+    </grok>
+  </parse>
+  path /var/log/customapp.log
+  pos_file /var/log/customapp.pos
+  path_key filename
+  tag custom.application
+</source>
+
+# Drop events with custom.application tag where loglevel field contains "debug" or "info" (case-insensitive match)
+
+<filter custom.application>
+  @type grep
+  <exclude>
+    key loglevel
+    pattern /debug|info/i
+  </exclude>
+</filter>
+
+#Add hostname and tag fields to all events ("records") with a Fluentd tag of custom.application
+ 
+ <filter custom.application>
+  @type record_transformer
+  <record>
+    hostname "#{Socket.gethostname}"
+    tag ${tag}
+  </record>
+</filter>
+
+#Write custom.application events to New Relic
+
+<match custom.application>
+  @type newrelic
+  api_key <YOUR INSERT KEY>
+</match>

--- a/examples/minimal_complete_config.conf
+++ b/examples/minimal_complete_config.conf
@@ -1,0 +1,27 @@
+#Tail arbitrary text/log file
+
+<source>
+  @type tail
+  <parse>
+    @type none
+  </parse>
+  path /home/logs/*
+  path_key file
+  tag sample.tag
+</source>
+
+#Add service_name field to all events ("records") with a Fluentd tag of sample.tag
+
+<filter sample.tag>
+  @type record_transformer
+  <record>
+    service_name ${tag}
+  </record>
+</filter>
+
+#Write sample.tag events to New Relic
+
+<match sample.tag>
+  @type newrelic
+  api_key <YOUR INSERT KEY>
+</match>

--- a/examples/multiline_log_parse.conf
+++ b/examples/multiline_log_parse.conf
@@ -1,0 +1,11 @@
+ <filter backend.application>
+    @type parser
+    <parse>
+      @type multiline_grok
+      grok_failure_key grokfailure
+      multiline_start_regex ^abc
+      <grok>
+        pattern %{GREEDYDATA:message}
+      </grok>
+    </parse>
+  </filter>

--- a/examples/parse_nginx.conf
+++ b/examples/parse_nginx.conf
@@ -1,0 +1,8 @@
+<source>
+  @type tail
+  <parse>
+    @type nginx
+  </parse>
+  path /var/log/nginx/error.log
+  tag nginx.error
+</source>

--- a/examples/syslog_input.conf
+++ b/examples/syslog_input.conf
@@ -1,0 +1,5 @@
+<source>
+  @type syslog
+  port 5140
+  tag syslog.messages
+</source>


### PR DESCRIPTION
Updated and added configuration files from https://github.com/newrelic/fluentd-examples. It makes more sense to keep relevant examples in the output plugin's repo.