### PR TITLE
[LOGGING-3263] Improve memory usage

### DIFF
--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -134,6 +134,8 @@ module Fluent
           return [compressed_payload]
         end
 
+        compressed_payload = nil # Free for GC
+
         if logs.length > 1 # we can split
           # let's split logs array by half, and try to create payloads again
           midpoint = logs.length / 2

--- a/lib/newrelic-fluentd-output/version.rb
+++ b/lib/newrelic-fluentd-output/version.rb
@@ -1,3 +1,3 @@
 module NewrelicFluentdOutput
-  VERSION = "1.1.9"
+  VERSION = "1.1.10"
 end


### PR DESCRIPTION
This change should significantly improve the memory usage of our write() function. With a chunk of 27MB and forced GC benchmark showed a decrease of 100MB, compared to previous version. 

Regarding execution time, this version is slightly slower with smaller chunks, and again slightly faster with larger chunks, than previous version. However, the slowdown is not significant. For instance a chunk of 27MB will take 200ms longer to process, but the memory baseline is much better. 

This is probably a trade-off we want to make.