### PR TITLE
Pull license key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Exactly one of the following:
 | api_key | your New Relic API Insert key |
 | license_key | your New Relic License key |
 
+If neither is specified, then it will use the NEW_RELIC_LICENSE_KEY environment variable, if set.
+
 ### Optional plugin configuration
 
 | Property | Description | Default value |

--- a/README.md
+++ b/README.md
@@ -31,14 +31,12 @@ For more info, review [Fluentd's official documentation](https://docs.fluentd.or
 
 ### Required plugin configuration
 
-Exactly one of the following:
+This plugin must be configured with either a New Relic API Insert key, or a New Relic License key.
+If both types of keys are specified, the API Insert key will take precedence.
 
-| Property | Description |
-|---|---|
-| api_key | your New Relic API Insert key |
-| license_key | your New Relic License key |
+To specify an API Insert key, either set the `api_key` property in the configuration, or set the `NEW_RELIC_API_KEY` environment variable. If both are specified, the configuration property will take precedence.
 
-If neither is specified, then it will use the NEW_RELIC_LICENSE_KEY environment variable, if set.
+To specify a license key, either set the `license_key` property in the configuration, or set the `NEW_RELIC_LICENSE_KEY` environment variable. If both are specified, the configuration property will take precedence.
 
 ### Optional plugin configuration
 

--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -50,6 +50,8 @@ module Fluent
 
       def configure(conf)
         super
+
+        @license_key ||= ENV["NEW_RELIC_LICENSE_KEY"]
         if @api_key.nil? && @license_key.nil?
           raise Fluent::ConfigError.new("'api_key' or 'license_key' parameter is required")
         end

--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -51,6 +51,7 @@ module Fluent
       def configure(conf)
         super
 
+        @api_key ||= ENV["NEW_RELIC_API_KEY"]
         @license_key ||= ENV["NEW_RELIC_LICENSE_KEY"]
         if @api_key.nil? && @license_key.nil?
           raise Fluent::ConfigError.new("'api_key' or 'license_key' parameter is required")

--- a/lib/newrelic-fluentd-output/version.rb
+++ b/lib/newrelic-fluentd-output/version.rb
@@ -1,3 +1,3 @@
 module NewrelicFluentdOutput
-  VERSION = "1.1.11"
+  VERSION = "1.1.12"
 end

--- a/lib/newrelic-fluentd-output/version.rb
+++ b/lib/newrelic-fluentd-output/version.rb
@@ -1,3 +1,3 @@
 module NewrelicFluentdOutput
-  VERSION = "1.1.12"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
When running fluentd as a pod in Kubernetes, it is better to specify the license as an environment variable from a secret rather writing in the fluentd config.