### PR TITLE
Update publish-unit-test-result-action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,8 +21,7 @@ jobs:
         run: bundle exec rake
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.5
+        uses: EnricoMi/publish-unit-test-result-action@v1.19
         if: always()
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           files: '**/TEST-*.xml'


### PR DESCRIPTION
Update the version of this action to its latest (1.19). This way the GITHUB_TOKEN is not longer required.