### PR TITLE
Issue 37 - Use record timestamp preferably

### DIFF
--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -76,11 +76,10 @@ module Fluent
 
       def package_record(record, timestamp)
         packaged = {
+          'timestamp' => resolveTimestamp(record['timestamp'], timestamp),
           # non-intrinsic attributes get put into 'attributes'
           'attributes' => record
         }
-
-        packaged['timestamp'] = resolveTimestamp(record['timestamp'], timestamp)
 
         # intrinsic attributes go at the top level
         if record.has_key?('message')

--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -75,14 +75,12 @@ module Fluent
       end
 
       def package_record(record, timestamp)
-        if defined? timestamp.nsec
-          timestamp = timestamp * 1000 + timestamp.nsec / 1_000_000
-        end
         packaged = {
-          'timestamp' => timestamp,
           # non-intrinsic attributes get put into 'attributes'
           'attributes' => record
         }
+
+        packaged['timestamp'] = resolveTimestamp(record['timestamp'], timestamp)
 
         # intrinsic attributes go at the top level
         if record.has_key?('message')
@@ -180,6 +178,17 @@ module Fluent
         gzip << Yajl.dump([payload])
         gzip.close
         io.string
+      end
+
+      def resolveTimestamp(recordTimestamp, fluentdTimestamp)
+        if recordTimestamp
+          recordTimestamp
+        else
+          if defined? fluentdTimestamp.nsec
+            fluentdTimestamp = fluentdTimestamp * 1000 + fluentdTimestamp.nsec / 1_000_000
+          end
+          fluentdTimestamp
+        end
       end
     end
   end

--- a/lib/newrelic-fluentd-output/version.rb
+++ b/lib/newrelic-fluentd-output/version.rb
@@ -1,3 +1,3 @@
 module NewrelicFluentdOutput
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/test/plugin/newrelic-fluentd-output_test.rb
+++ b/test/plugin/newrelic-fluentd-output_test.rb
@@ -231,7 +231,7 @@ class Fluent::Plugin::NewrelicOutputTest < Test::Unit::TestCase
         message['logs'][0]['timestamp'] == @event_time_integer_out }
     end
 
-    test "fluent's event time is used if record has no timestamp (Fluent:EventTime case)" do
+    test "fluentd's event time is used if record has no timestamp (Fluent:EventTime case)" do
       stub_request(:any, @base_uri).to_return(status: @vortex_success_code)
 
       driver = create_driver(@simple_config)

--- a/test/plugin/newrelic-fluentd-output_test.rb
+++ b/test/plugin/newrelic-fluentd-output_test.rb
@@ -231,7 +231,7 @@ class Fluent::Plugin::NewrelicOutputTest < Test::Unit::TestCase
         message['logs'][0]['timestamp'] == @event_time_integer_out }
     end
 
-    test "'timestamp' field is added from event time (Fluent:EventTime case)" do
+    test "fluent's event time is used if record has no timestamp (Fluent:EventTime case)" do
       stub_request(:any, @base_uri).to_return(status: @vortex_success_code)
 
       driver = create_driver(@simple_config)
@@ -242,6 +242,20 @@ class Fluent::Plugin::NewrelicOutputTest < Test::Unit::TestCase
       assert_requested(:post, @base_uri) { |request|
         message = parsed_gzipped_json(request.body)
         message['logs'][0]['timestamp'] == @event_time_fluent_out }
+    end
+
+    test "'timestamp' field from record log has preference over fluentd's event time (Fluent:EventTime case)" do
+      stub_request(:any, @base_uri).to_return(status: @vortex_success_code)
+
+      driver = create_driver(@simple_config)
+      record_timestamp = 654321
+      driver.run(default_tag: 'test') do
+        driver.feed(@event_time_fluent, {:message => "Test message", :timestamp => record_timestamp})
+      end
+
+      assert_requested(:post, @base_uri) { |request|
+        message = parsed_gzipped_json(request.body)
+        message['logs'][0]['timestamp'] == record_timestamp }
     end
 
     test "all other attributes other than message and timestamp are placed in an attributes block" do


### PR DESCRIPTION
https://github.com/newrelic/newrelic-fluentd-output/issues/37

If the record received by the plugin has a `timestamp` key, that is used to set the log timestamp.
Otherwise the timestamp at which fluentd processed the log is used.