### PR TITLE
fix: plugin could goes into endless looping when a log size is larger than 1 MB in compressed size

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   ci:
     name: Continuous Delivery pipeline
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   ci:
     name: Continuous Integration pipeline
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code

--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -138,6 +138,7 @@ module Fluent
           return [compressed_payload]
         end
 
+        compressed_payload_bytesize = compressed_payload.bytesize
         compressed_payload = nil # Free for GC
 
         if logs.length > 1 # we can split
@@ -147,7 +148,8 @@ module Fluent
           second_half = get_compressed_payloads(logs.slice(midpoint, logs.length))
           return first_half + second_half
         else
-          log.error("Can't compress record below required maximum packet size and it will be discarded.")
+          log.error("Can't compress record below required maximum packet size and it will be discarded. " +
+                      "Record timestamp: #{logs[0]['timestamp']}. Compressed size: #{compressed_payload_bytesize} bytes. Uncompressed size: #{payload.to_json.bytesize} bytes.")
           return []
         end
       end

--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -147,7 +147,7 @@ module Fluent
           second_half = get_compressed_payloads(logs.slice(midpoint, logs.length))
           return first_half + second_half
         else
-          log.error("Can't compress record below required maximum packet size and it will be discarded. Record: #{logs[0]}")
+          log.error("Can't compress record below required maximum packet size and it will be discarded.")
           return []
         end
       end

--- a/lib/newrelic-fluentd-output/version.rb
+++ b/lib/newrelic-fluentd-output/version.rb
@@ -1,3 +1,3 @@
 module NewrelicFluentdOutput
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end


### PR DESCRIPTION
The New Relic Fluentd Output Plugin does not support forwarding logs that exceed 1 MB in compressed size. When such a situation arises, the log is discarded and an error message is generated. However, this error log includes the discarded long log. If Fluentd is configured to save the internal logs in a file and its content is forwarded to New Relic, this could potentially lead to an infinite loop. This pull request addresses this issue by removing the long log from the error message, thereby preventing such scenarios. The offending log timestamp and its uncompressed/compressed size in bytes are added into that error message for error tracing purposes.  

