### PR TITLE
feat: replace yajl-ruby with json gem

### DIFF
--- a/lib/fluent/plugin/out_newrelic.rb
+++ b/lib/fluent/plugin/out_newrelic.rb
@@ -18,7 +18,7 @@ require 'net/http'
 require 'uri'
 require 'zlib'
 require 'newrelic-fluentd-output/version'
-require 'yajl'
+require 'json'
 
 module Fluent
   module Plugin
@@ -149,7 +149,7 @@ module Fluent
           return first_half + second_half
         else
           log.error("Can't compress record below required maximum packet size and it will be discarded. " +
-                      "Record timestamp: #{logs[0]['timestamp']}. Compressed size: #{compressed_payload_bytesize} bytes. Uncompressed size: #{payload.to_json.bytesize} bytes.")
+                      "Record timestamp: #{logs[0]['timestamp']}. Compressed size: #{compressed_payload_bytesize} bytes. Uncompressed size: #{sanitized_json(payload).bytesize} bytes.")
           return []
         end
       end
@@ -171,14 +171,41 @@ module Fluent
       def compress(payload)
         io = StringIO.new
         gzip = Zlib::GzipWriter.new(io)
-
-        # Fluentd can run with a version of Ruby (2.1.0) whose to_json method doesn't support non-ASCII characters.
-        # So we use Yajl, which can handle all Unicode characters. Apparently this library is what Fluentd uses
-        # internally, so it is installed by default with td-agent.
-        # See https://github.com/fluent/fluentd/issues/215
-        gzip << Yajl.dump([payload])
+        gzip << sanitized_json([payload])
         gzip.close
         io.string
+      end
+
+      # Unlike Yajl, which passed invalid UTF-8 byte sequences through, the json gem
+      # raises an error for them. Sanitize the payload and retry rather than losing
+      # the whole chunk because of a single bad record.
+      # See https://github.com/fluent/fluentd/issues/215
+      def sanitized_json(payload)
+        JSON.generate(payload)
+      rescue JSON::GeneratorError, EncodingError
+        JSON.generate(scrub_invalid_utf8(payload))
+      end
+
+      def scrub_invalid_utf8(value)
+        case value
+        when String
+          if value.encoding == Encoding::UTF_8
+            value.valid_encoding? ? value : value.scrub('?')
+          elsif value.encoding == Encoding::ASCII_8BIT
+            # Treat binary as UTF-8 bytes: encode() would replace every byte >= 0x80,
+            # while scrubbing preserves any valid UTF-8 sequences in the string.
+            s = value.dup.force_encoding(Encoding::UTF_8)
+            s.valid_encoding? ? s : s.scrub!('?')
+          else
+            value.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: '?')
+          end
+        when Hash
+          value.each_with_object({}) { |(k, v), h| h[scrub_invalid_utf8(k)] = scrub_invalid_utf8(v) }
+        when Array
+          value.map { |v| scrub_invalid_utf8(v) }
+        else
+          value
+        end
       end
 
       def resolveTimestamp(recordTimestamp, fluentdTimestamp)

--- a/test/plugin/newrelic-fluentd-output_test.rb
+++ b/test/plugin/newrelic-fluentd-output_test.rb
@@ -285,6 +285,34 @@ class Fluent::Plugin::NewrelicOutputTest < Test::Unit::TestCase
         message['logs'][0]['message'] == 'ういじゅん' }
     end
 
+    test "sanitizes messages with invalid UTF-8 byte sequences" do
+      stub_request(:any, @base_uri).to_return(status: @vortex_success_code)
+
+      driver = create_driver(@simple_config)
+      driver.run(default_tag: 'test') do
+        driver.feed({ :message => "foo \xff bar".force_encoding(Encoding::UTF_8) })
+      end
+
+      assert_requested(:post, @base_uri) { |request|
+        message = parsed_gzipped_json(request.body)
+        message['logs'][0]['message'] == "foo ? bar" }
+    end
+
+    test "sanitizes binary-encoded attribute values" do
+      stub_request(:any, @base_uri).to_return(status: @vortex_success_code)
+
+      driver = create_driver(@simple_config)
+      driver.run(default_tag: 'test') do
+        # "\xe3\x81\x82" is a valid UTF-8 sequence ("あ") and must be preserved
+        driver.feed({ :message => "Test message", :other => "\xff \xe3\x81\x82 binary".b })
+      end
+
+      assert_requested(:post, @base_uri) { |request|
+        message = parsed_gzipped_json(request.body)
+        message['logs'][0]['message'] == 'Test message' &&
+        message['logs'][0]['attributes']['other'] == "? あ binary" }
+    end
+
     test "handles messages without a 'message' field" do
       stub_request(:any, @base_uri).to_return(status: @vortex_success_code)
 


### PR DESCRIPTION
Hi, I'm a member of the Fluentd core team.
Since `yajl-ruby` is no longer maintained, we are planning to replace it, and it will no longer be bundled starting from the upcoming Fluentd v1.20.
Ref. https://github.com/fluent/fluentd/pull/5383

This PR replaces `yajl-ruby` with the standard `json` gem to ensure future compatibility for this plugin.

`yajl-ruby` is effectively unmaintained and fails to build on Ruby 4.1, so this PR removes the plugin's dependency on it and switches JSON serialization to the Ruby standard library's `json` gem (`Yajl.dump` → `JSON.generate`).

This plugin originally switched to Yajl because the json gem raises an error on strings containing invalid UTF-8 byte sequences (https://github.com/fluent/fluentd/issues/215). To handle such records, the payload is now sanitized and retried when JSON generation fails: invalid bytes are replaced with '?', and binary (ASCII-8BIT) strings are scrubbed as UTF-8 so that any valid UTF-8 sequences they contain are preserved.

1. Future Compatibility: `yajl-ruby` is no longer actively maintained and relies on internal C APIs that are removed in Ruby 4.1. Migrating to the standard `json` gem ensures the plugin can continue to be built and used in future Ruby environments. Ref. https://github.com/ruby/ruby/pull/15447, https://github.com/brianmario/yajl-ruby/issues/233
2. Performance: The standard `json` gem has seen significant improvements in recent updates and now outperforms `yajl-ruby`.

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'yajl-ruby', require: 'yajl'
  gem 'json'
end

Benchmark.ips do |x|
  json = '{"a":"Alpha","b":true,"c":12345,"d":[true,[false,[-123456789,null],3.9676,["Something else.",false],null]],"e":{"zero":null,"one":1,"two":2,"three":[3],"four":[0,1,2,3,4]},"f":null,"h":{"a":{"b":{"c":{"d":{"e":{"f":{"g":null}}}}}}},"i":[[[[[[[null]]]]]]]}'

  x.report('Yajl.load') {
    Yajl.load(json)
  }
  x.report('JSON.parse') {
    JSON.parse(json)
  }

  x.compare!
end
```

```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [x86_64-linux]
Warming up --------------------------------------
           Yajl.load    20.019k i/100ms
          JSON.parse    80.144k i/100ms
Calculating -------------------------------------
           Yajl.load    202.875k (± 0.2%) i/s    (4.93 μs/i) -      1.021M in   5.032515s
          JSON.parse    808.103k (± 0.2%) i/s    (1.24 μs/i) -      4.087M in   5.057949s

Comparison:
JSON.parse:   808103.0 i/s
 Yajl.load:   202874.5 i/s - 3.98x  slower
```
