### PR TITLE
NR-587388: Add scheduled Trivy security scan and Dependabot scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "11:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "11:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ruby"
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,6 @@ jobs:
     name: Continuous Integration pipeline
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
       checks: write
       pull-requests: write
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,17 +2,24 @@ name: New Relic Fluentd Output Plugin - Pull Request
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Continuous Integration pipeline
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
 
       - name: Setup Ruby, bundler and install dependencies
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby-2.5.8
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -21,7 +28,7 @@ jobs:
         run: bundle exec rake
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        uses: EnricoMi/publish-unit-test-result-action@95a3aff882d4abe2838b187c66477be7fbf3ddb8 # v1.19
         if: always()
         with:
           files: '**/TEST-*.xml'

--- a/.github/workflows/security_scan_pr_schedule.yaml
+++ b/.github/workflows/security_scan_pr_schedule.yaml
@@ -1,0 +1,33 @@
+name: Security Scan
+
+on:
+  pull_request:
+    branches: [master, main]
+  pull_request_target:
+    types: [opened, reopened]
+  schedule:
+    # Every day at 11:30 AM IST (6:00 AM UTC)
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot-notify:
+    name: Notify Slack on Dependabot PR
+    # IMPORTANT: This job uses pull_request_target which has full secrets access.
+    # Do NOT add a `checkout` step here — that would run PR-supplied code with secrets.
+    # This job's only purpose is to POST to Slack with metadata; nothing else.
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          payload: |
+            {
+              "text": ":robot_face: Dependabot opened a PR in ${{ github.repository }}\nTitle: ${{ github.event.pull_request.title }}\nPR: ${{ github.event.pull_request.html_url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TRIVY_WEBHOOK_URL }}

--- a/.github/workflows/security_scan_pr_schedule.yaml
+++ b/.github/workflows/security_scan_pr_schedule.yaml
@@ -5,10 +5,6 @@ on:
     branches: [master, main]
   pull_request_target:
     types: [opened, reopened]
-  schedule:
-    # Every day at 11:30 AM IST (6:00 AM UTC)
-    - cron: "0 6 * * *"
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/security_scan_pr_schedule.yaml
+++ b/.github/workflows/security_scan_pr_schedule.yaml
@@ -1,8 +1,6 @@
 name: Security Scan
 
 on:
-  pull_request:
-    branches: [master, main]
   pull_request_target:
     types: [opened, reopened]
 


### PR DESCRIPTION
### Changes done

- Adds Dependabot config for weekly GitHub Actions version updates — runs daily at 11:30 AM IST on master
- Adds Slack notifications: schedule-time every new Dependabot PR

### Why no Trivy scan for newrelic-fluentd-output:

This repo publishes a Ruby gem — source code only, no Docker image artifact. Trivy's filesystem scan is designed for scanning installed gem environments (inside containers), not a gem's source repository. Running it here produces no findings and adds no value. CVE detection for this repo is handled by Dependabot (bundler ecosystem), which is the correct tool for Ruby gem dependency scanning.